### PR TITLE
css hotfix

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -462,6 +462,9 @@ td.chbox {
     width: 85%;
 }
 
+.post.post-parent {
+    padding-bottom: 20px;
+}
 .post {
     padding: 20px 20px 0px 15px;
 }


### PR DESCRIPTION
Posts that didn't start at the root level are no longer cut off at the bottom